### PR TITLE
Redefine board struct to make operations on board limits simpler

### DIFF
--- a/apps/heroes_server/lib/game/board.ex
+++ b/apps/heroes_server/lib/game/board.ex
@@ -17,18 +17,11 @@ defmodule Game.Board do
   """
   @type wall :: tile
 
-  @typedoc """
-  A board is defined by:
-
-  - `cols`: number of columns
-  - `rows`: number of rows
-  - `walls`: `MapSet` of `t:wall/0`
-  """
-  @type t :: %__MODULE__{
-          cols: pos_integer(),
-          rows: pos_integer(),
-          walls: MapSet.t(wall)
-        }
+  @opaque t :: %__MODULE__{
+            cols: pos_integer(),
+            rows: pos_integer(),
+            walls: MapSet.t(wall)
+          }
 
   @enforce_keys [:cols, :rows, :walls]
 

--- a/apps/heroes_server/lib/game/board.ex
+++ b/apps/heroes_server/lib/game/board.ex
@@ -5,6 +5,7 @@ defmodule Game.Board do
 
   alias __MODULE__
   alias Game.BoardRange
+  alias GameError.BadSize
 
   @typedoc """
   Walkable board cell
@@ -37,6 +38,38 @@ defmodule Game.Board do
   Allowed movements.
   """
   @type moves :: :up | :down | :left | :right
+
+  @doc """
+  Create a board struct from given options.
+
+  Requires a positive number of `cols`, `rows`
+  and optionally a list of `t:wall/0`.
+  """
+  @spec new(keyword()) :: t
+  def new(opts) do
+    %Board{
+      cols: fetch!(opts, :cols),
+      rows: fetch!(opts, :rows),
+      walls: get(opts, :walls)
+    }
+  end
+
+  @spec fetch!(keyword(), atom()) :: pos_integer()
+  defp fetch!(opts, size) do
+    value = Keyword.fetch!(opts, size)
+
+    if is_integer(value) and value > 0 do
+      value
+    else
+      raise BadSize, size: size, value: value
+    end
+  end
+
+  @spec get(keyword(), :walls) :: MapSet.t(wall)
+  defp get(opts, :walls) do
+    walls = Keyword.get(opts, :walls, [])
+    MapSet.new(walls)
+  end
 
   @doc """
   Generate all tiles in a board.

--- a/apps/heroes_server/lib/game_error/bad_size.ex
+++ b/apps/heroes_server/lib/game_error/bad_size.ex
@@ -4,8 +4,11 @@ defmodule GameError.BadSize do
   defexception [:message]
 
   @impl true
-  def exception([{size, value}]) when is_atom(size) and is_binary(value) do
-    msg = "Invalid board dimensions, got #{size}: #{value}"
+  def exception(info) do
+    {:ok, size} = Keyword.fetch(info, :size)
+    {:ok, value} = Keyword.fetch(info, :value)
+
+    msg = "Invalid board dimensions, got #{size}: #{inspect(value)}"
     %BadSize{message: msg}
   end
 end

--- a/apps/heroes_server/lib/utils/game_boards.ex
+++ b/apps/heroes_server/lib/utils/game_boards.ex
@@ -4,7 +4,6 @@ defmodule Utils.GameBoards do
   """
 
   alias Game.{Board, BoardRange}
-  alias GameError.BadSize
 
   @callback spec :: Board.t()
   @callback tiles :: list(Board.tile())
@@ -13,12 +12,7 @@ defmodule Utils.GameBoards do
 
   @doc false
   defmacro __using__(opts) do
-    board_spec = %Board{
-      cols: get(opts, :cols),
-      rows: get(opts, :rows),
-      walls: get(opts, :walls)
-    }
-
+    board_spec = Board.new(opts)
     tiles = Board.generate(board_spec)
 
     quote do
@@ -39,21 +33,6 @@ defmodule Utils.GameBoards do
 
       @impl true
       def play(tile, move), do: Board.play(tile, move, @board_spec)
-    end
-  end
-
-  defp get(opts, :walls) do
-    walls = Keyword.get(opts, :walls, [])
-    MapSet.new(walls)
-  end
-
-  defp get(opts, size) do
-    value = Keyword.fetch!(opts, size)
-
-    if is_integer(value) and value > 0 do
-      value
-    else
-      raise BadSize, [{size, Macro.to_string(value)}]
     end
   end
 end

--- a/apps/heroes_server/lib/utils/game_boards.ex
+++ b/apps/heroes_server/lib/utils/game_boards.ex
@@ -5,7 +5,6 @@ defmodule Utils.GameBoards do
 
   alias Game.{Board, BoardRange}
 
-  @callback spec :: Board.t()
   @callback tiles :: list(Board.tile())
   @callback attack_range(Board.tile()) :: BoardRange.t()
   @callback play(Board.tile(), Board.moves()) :: Board.tile()
@@ -21,9 +20,6 @@ defmodule Utils.GameBoards do
       alias Game.Board
 
       @board_spec unquote(Macro.escape(board_spec))
-
-      @impl true
-      def spec, do: @board_spec
 
       @impl true
       def tiles, do: unquote(tiles)

--- a/apps/heroes_server/test/board_test.exs
+++ b/apps/heroes_server/test/board_test.exs
@@ -1,10 +1,52 @@
 defmodule Game.BoardTest do
   use ExUnit.Case, async: true
 
+  alias Game.Board
+  alias GameError.BadSize
+
   @board_3x2 GameBoards.Test3x2
   @board_4x3_w5 GameBoards.Test4x3w5
   @board_4x4 GameBoards.Test4x4
   @board_4x4_w2 GameBoards.Test4x4w2
+
+  describe "Creating a board struct" do
+    test "requires cols, rows and optionally walls" do
+      blank_board = Board.new(cols: 4, rows: 1)
+
+      assert %Board{cols: 4, rows: 1, walls: empty} = blank_board
+      assert empty = MapSet.new([])
+
+      blocked_tiles = [{0, 0}, {1, 4}]
+      board = Board.new(cols: 2, rows: 5, walls: blocked_tiles)
+
+      assert %Board{cols: 2, rows: 5, walls: walls} = board
+      assert walls = MapSet.new(blocked_tiles)
+    end
+
+    test "without required options raises KeyError" do
+      assert_raise KeyError, fn ->
+        Board.new(rows: 3)
+      end
+
+      assert_raise KeyError, fn ->
+        Board.new(cols: 1, walls: [])
+      end
+    end
+
+    test "with non positive integers for cols and rows raises BadSize" do
+      assert_raise BadSize, fn ->
+        Board.new(cols: 3, rows: -1)
+      end
+
+      assert_raise BadSize, fn ->
+        Board.new(cols: 0, rows: 2)
+      end
+
+      assert_raise BadSize, fn ->
+        Board.new(cols: 4, rows: 5.0)
+      end
+    end
+  end
 
   describe "Tile generation on" do
     @tag board: @board_3x2

--- a/apps/heroes_server/test/board_test.exs
+++ b/apps/heroes_server/test/board_test.exs
@@ -50,14 +50,13 @@ defmodule Game.BoardTest do
 
   describe "Tile generation on" do
     @tag board: @board_3x2
-    test "3x2 board without walls", %{board: board} do
-      assert contains?(board, [{0, 0}, {0, 1}, {1, 0}, {1, 1}, {2, 0}, {2, 1}])
+    test "3x2 blank board", %{board: board} do
+      assert_tiles(board, [{0, 0}, {0, 1}, {1, 0}, {1, 1}, {2, 0}, {2, 1}])
     end
 
     @tag board: @board_4x3_w5
     test "4x3 board with 5 walls", %{board: board} do
-      assert contains?(board, [{0, 1}, {1, 0}, {1, 1}, {1, 2}, {2, 1}, {3, 1}, {3, 2}])
-      refute contains?(board, board.spec.walls)
+      assert_tiles(board, [{0, 1}, {1, 0}, {1, 1}, {1, 2}, {2, 1}, {3, 1}, {3, 2}])
     end
   end
 
@@ -117,11 +116,11 @@ defmodule Game.BoardTest do
     end
   end
 
-  defp contains?(board, candidates) do
-    tiles = MapSet.new(board.tiles())
-    expected = MapSet.new(candidates)
+  defp assert_tiles(board, candidates) do
+    tiles = Enum.sort(board.tiles())
+    expected = Enum.sort(candidates)
 
-    MapSet.equal?(tiles, expected)
+    assert tiles == expected
   end
 
   defp set_tile(%{tile: tile, move_fn: move}), do: [move_fn: &move.(tile, &1)]

--- a/apps/heroes_server/test/board_test.exs
+++ b/apps/heroes_server/test/board_test.exs
@@ -11,16 +11,12 @@ defmodule Game.BoardTest do
 
   describe "Creating a board struct" do
     test "requires cols, rows and optionally walls" do
-      blank_board = Board.new(cols: 4, rows: 1)
+      board_2x5_blank = Board.new(cols: 2, rows: 5)
+      board_2x5_walls = Board.new(cols: 2, rows: 5, walls: [{0, 0}, {1, 4}])
 
-      assert %Board{cols: 4, rows: 1, walls: empty} = blank_board
-      assert empty = MapSet.new([])
-
-      blocked_tiles = [{0, 0}, {1, 4}]
-      board = Board.new(cols: 2, rows: 5, walls: blocked_tiles)
-
-      assert %Board{cols: 2, rows: 5, walls: walls} = board
-      assert walls = MapSet.new(blocked_tiles)
+      assert %Board{} = board_2x5_blank
+      assert %Board{} = board_2x5_walls
+      refute board_2x5_blank == board_2x5_walls
     end
 
     test "without required options raises KeyError" do


### PR DESCRIPTION
Change `cols` and `rows`  for actual x and y ranges.